### PR TITLE
add Kconfig with LUA custom stack size

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,11 @@
+menu "Lua"
+    config LUA_MAXSTACK
+        int "Stack size limit"
+        default 1000000
+        help
+            Limits the size of the Lua stack.
+            Change it if you need a different limit. This limit is arbitrary;
+            its only purpose is to stop Lua from consuming unlimited stack
+            space (and to reserve some numbers for pseudo-indices).
+
+endmenu

--- a/include/luaconf.h
+++ b/include/luaconf.h
@@ -760,7 +760,7 @@
 ** (It must fit into max(int)/2.)
 */
 #if 1000000 < (INT_MAX / 2)
-#define LUAI_MAXSTACK		1000000
+#define LUAI_MAXSTACK		CONFIG_LUA_MAXSTACK
 #else
 #define LUAI_MAXSTACK		(INT_MAX / 2u)
 #endif


### PR DESCRIPTION
This PR provides **LUA** menu in menuconfig and adds possibility to set own LUA stack size.
By default  **Lua custome stack size** is disable
![image](https://github.com/user-attachments/assets/b9319b14-4b73-4c1d-ba08-6a51275778c0)
